### PR TITLE
Collection changed fix

### DIFF
--- a/SampleApp.android/QuickCross/DataBindableListAdapter.cs
+++ b/SampleApp.android/QuickCross/DataBindableListAdapter.cs
@@ -103,8 +103,12 @@ namespace QuickCross
         /// <param name="e">See http://blog.stephencleary.com/2009/07/interpreting-notifycollectionchangedeve.html for details</param>
         protected virtual void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
-            NotifyDataSetChanged(); // MQC TODO: Check if this should & can be optimized, see for details documentation at http://blog.stephencleary.com/2009/07/interpreting-notifycollectionchangedeve.html
-            if (viewExtensionPoints != null) viewExtensionPoints.OnCollectionChanged(sender, e);
+            ApplicationBase.RunOnUIThread(() =>
+            {
+                NotifyDataSetChanged();
+                    // MQC TODO: Check if this should & can be optimized, see for details documentation at http://blog.stephencleary.com/2009/07/interpreting-notifycollectionchangedeve.html
+                if (viewExtensionPoints != null) viewExtensionPoints.OnCollectionChanged(sender, e);
+            });
         }
 
         private void DataBindableListAdapter_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/SampleApp.ios/QuickCross/DataBindableUITableViewSource.cs
+++ b/SampleApp.ios/QuickCross/DataBindableUITableViewSource.cs
@@ -118,11 +118,15 @@ namespace QuickCross
 		/// <param name="e">See http://blog.stephencleary.com/2009/07/interpreting-notifycollectionchangedeve.html for details</param>
 		protected virtual void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			if (!ignoreCollectionChanged)
-			{
-				tableView.ReloadData(); // QC TODO: Check if this should & can be optimized, see for details documentation at http://blog.stephencleary.com/2009/07/interpreting-notifycollectionchangedeve.html
-			}
-			if (viewExtensionPoints != null) viewExtensionPoints.OnCollectionChanged(sender, e);
+		    ApplicationBase.RunOnUIThread(() =>
+		    {
+		        if (!ignoreCollectionChanged)
+		        {
+		            tableView.ReloadData();
+		                // QC TODO: Check if this should & can be optimized, see for details documentation at http://blog.stephencleary.com/2009/07/interpreting-notifycollectionchangedeve.html
+		        }
+		        if (viewExtensionPoints != null) viewExtensionPoints.OnCollectionChanged(sender, e);
+		    });
 		}
 
 		private void DataBindableListAdapter_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
If an observeable collection is changed from outside the ViewModel, in a
callback from a service. The code will throw an execption, because the
model is updated on the wrong thread. This code will fix the rror.
